### PR TITLE
Support paste action with listening to input instead of keyup

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -21,7 +21,7 @@ module.exports = function tabto(input) {
   }
 
   var currentValue = input.value;
-  input.addEventListener('keyup', function () {
+  input.addEventListener('input', function () {
     // If the value change, check for tab
     if (input.value !== currentValue) {
       if (input.value.length >= maxLength) {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function tabto (input) {
   }
 
   let currentValue = input.value
-  input.addEventListener('keyup', function () {
+  input.addEventListener('input', function () {
     // If the value change, check for tab
     if (input.value !== currentValue) {
       if (input.value.length >= maxLength) {


### PR DESCRIPTION
To solve issue #5 I changed to use input event instead of keyup. This catches pasting  text with mouse and keyboard. Let me know if there is a problem with this solution.