### PR TITLE
Output library in multiple formats with rollup

### DIFF
--- a/dist/browser.js
+++ b/dist/browser.js
@@ -1,0 +1,42 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (global.tabto = factory());
+}(this, (function () { 'use strict';
+
+  /* global HTMLInputElement */
+  function tabto(input) {
+    if (!(input instanceof HTMLInputElement)) {
+      console.error('tabto() expect a DOM Input element.');
+      return;
+    }
+
+    if (!input.dataset.tabTarget) {
+      console.error('tabto() expect the DOM Input element to have a "data-tab-target" attribute.');
+      return;
+    }
+
+    var maxLength = input.maxLength;
+    var next = document.querySelector(input.dataset.tabTarget);
+
+    if (!next || !maxLength) {
+      console.error('tabto() a valid target and a maxLength on the provided input.');
+      return;
+    }
+
+    var currentValue = input.value;
+    input.addEventListener('input', function () {
+      // If the value change, check for tab
+      if (input.value !== currentValue) {
+        if (input.value.length >= maxLength) {
+          next.focus();
+        }
+      }
+
+      currentValue = input.value;
+    });
+  }
+
+  return tabto;
+
+})));

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* global HTMLInputElement */
 function tabto(input) {
   if (!(input instanceof HTMLInputElement)) {
@@ -33,4 +31,4 @@ function tabto(input) {
   });
 }
 
-module.exports = tabto;
+export default tabto;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /* global HTMLInputElement */
 
-module.exports = function tabto (input) {
+export default function tabto (input) {
   if (!(input instanceof HTMLInputElement)) {
     console.error('tabto() expect a DOM Input element.')
     return

--- a/package.json
+++ b/package.json
@@ -2,19 +2,22 @@
   "name": "@jolicode/tabto",
   "version": "1.1.0",
   "description": "Auto-tabulation for your inputs. Tiny helper that focus on the next field when a field reach maxLength.",
-  "browser": "dist/index.js",
+  "main": "dist/index.js",
+  "browser": "dist/browser.js",
   "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.1",
     "@babel/core": "^7.1",
     "@babel/preset-env": "^7.1",
     "np": "^3.0.4",
+    "rollup": "^0.66.4",
+    "rollup-plugin-babel": "^4.0.3",
     "standard": "^12.0.1"
   },
   "scripts": {
     "test": "exit 0",
     "lint": "standard *.js --fix",
-    "build": "babel index.js -d dist",
+    "build": "rollup -c",
     "release": "np"
   },
   "babel": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,23 @@
+import babel from 'rollup-plugin-babel'
+
+module.exports = {
+  input: 'index.js',
+  output: [
+    {
+      file: 'dist/index.js',
+      format: 'cjs'
+    }, {
+      file: 'dist/browser.js',
+      format: 'umd',
+      name: 'tabto'
+    }, {
+      file: 'dist/index.es.js',
+      format: 'esm'
+    }
+  ],
+  plugins: [
+    babel({
+      exclude: 'node_modules/**'
+    })
+  ]
+}


### PR DESCRIPTION
Used rollup to output lib in multiple module formats. UMD can be directly consumed in browser and commonjs and es module can be used when bundling.

Should close #13 